### PR TITLE
Improve download process

### DIFF
--- a/create_vsix.sh
+++ b/create_vsix.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 yarn install
 yarn vscode:prepublish
-yarn run vsce package
+yarn package

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daffodil-debug",
   "displayName": "Daffodil Debug",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "Daffodil",
   "description": "Daffodil Schema Debugger - debug Apache Daffodil schema files.",
   "author": {
@@ -173,7 +173,8 @@
             "request": "launch",
             "name": "Ask for file name",
             "program": "${workspaceFolder}/${command:AskForProgramName}",
-            "stopOnEntry": true
+            "stopOnEntry": true,
+            "preLaunchTask": "Run Debbuger"
           }
         ],
         "configurationSnippets": [
@@ -185,7 +186,8 @@
               "request": "launch",
               "name": "Ask for file name",
               "program": "^\"\\${workspaceFolder}/\\${command:AskForProgramName}\"",
-              "stopOnEntry": true
+              "stopOnEntry": true,
+              "preLaunchTask": "Run Debbuger"
             }
           }
         ],

--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -12,7 +12,8 @@
 			"data": "${workspaceFolder}/works.jpg",
 			"stopOnEntry": true,
 			"trace": false,
-			"debugServer": 4711
+			"debugServer": 4711,
+			"preLaunchTask": "Run Debugger"
 		}
 	]
 }

--- a/sampleWorkspace/.vscode/tasks.json
+++ b/sampleWorkspace/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Debugger",
+            "type": "shell",
+            "command": "./daffodil-debugger-${input:daffodilDebugVersion}/bin/da-podil",
+            "windows": {
+                "command": ".\\daffodil-debugger-${input:daffodilDebugVersion}\\bin\\da-podil.bat"
+            },
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "new",
+                "showReuseMessage": false,
+                "clear": true
+            }
+        }
+    ],
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "daffodilDebugVersion",
+            "description": "Enter in daffodil debugger version to run:",
+        }
+    ]
+}

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -51,7 +51,7 @@ export async function getDebugger() {
             fs.unlinkSync(filePath);
         }
 
-        // Run debugger based on OS
+        // Stop debugger if running
         if (os.platform() === 'win32') {
             // Windows stop debugger if already running
             child_process.exec("tskill java");
@@ -61,18 +61,6 @@ export async function getDebugger() {
             child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0") // ensure debugger server not running and
             child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebuggerVersion}/bin/da-podil`)     // make sure da-podil is executable
         }
-
-        // Assign script name based on os platform
-        let scriptName = os.platform() === 'win32' ? "da-podil.bat": "da-podil";
-
-        // Start debugger in terminal based on scriptName
-        let terminal = vscode.window.createTerminal({
-            name: scriptName,
-            cwd: `${rootPath}/daffodil-debugger-${dapodilDebuggerVersion}/bin/`,
-            hideFromUser: false,
-            shellPath: scriptName,
-        });
-        terminal.show();
 
         // Wait for 5000 ms to make sure debugger is running before the extension tries to connect to it
         await delay(5000);


### PR DESCRIPTION
Updated the debugger to be ran via a task so that it will run every time.
The first time the debugger is ran it should download the version of the debugger entered by the user. Then after you will prompted for the debugger you have locally so that it can be ran in a new terminal instance