### PR TITLE
Version Input & Download Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
   "main": "./dist/ext/extension.js",
   "browser": "./dist/web/extension.js",
   "activationEvents": [
-    "onDebugResolve:daffodil",
-    "onDebugDynamicConfigurations:daffodil",
-    "onCommand:extension.daffodil-debug.getProgramName",
-    "onCommand:extension.daffodil-debug.runEditorContents",
-    "onCommand:extension.daffodil-debug.debugEditorContents"
+    "onDebugResolve:dfdl",
+    "onDebugDynamicConfigurations:dfdl",
+    "onCommand:extension.dfdl-debug.getProgramName",
+    "onCommand:extension.dfdl-debug.runEditorContents",
+    "onCommand:extension.dfdl-debug.debugEditorContents"
   ],
   "workspaceTrust": {
     "request": "never"
@@ -78,48 +78,48 @@
     "menus": {
       "editor/title/run": [
         {
-          "command": "extension.daffodil-debug.runEditorContents",
+          "command": "extension.dfdl-debug.runEditorContents",
           "when": "resourceLangId == markdown"
         },
         {
-          "command": "extension.daffodil-debug.debugEditorContents",
+          "command": "extension.dfdl-debug.debugEditorContents",
           "when": "resourceLangId == markdown"
         }
       ],
       "commandPalette": [
         {
-          "command": "extension.daffodil-debug.debugEditorContents",
+          "command": "extension.dfdl-debug.debugEditorContents",
           "when": "resourceLangId == markdown"
         },
         {
-          "command": "extension.daffodil-debug.runEditorContents",
+          "command": "extension.dfdl-debug.runEditorContents",
           "when": "resourceLangId == markdown"
         }
       ],
       "debug/variables/context": [
         {
-          "command": "extension.daffodil-debug.toggleFormatting",
-          "when": "debugType == 'daffodil' && debugProtocolVariableMenuContext == 'simple'"
+          "command": "extension.dfdl-debug.toggleFormatting",
+          "when": "debugType == 'dfdl' && debugProtocolVariableMenuContext == 'simple'"
         }
       ]
     },
     "commands": [
       {
-        "command": "extension.daffodil-debug.debugEditorContents",
+        "command": "extension.dfdl-debug.debugEditorContents",
         "title": "Debug File",
         "category": "Daffodil Debug",
         "enablement": "!inDebugMode",
         "icon": "$(debug-alt)"
       },
       {
-        "command": "extension.daffodil-debug.runEditorContents",
+        "command": "extension.dfdl-debug.runEditorContents",
         "title": "Run File",
         "category": "Daffodil Debug",
         "enablement": "!inDebugMode",
         "icon": "$(play)"
       },
       {
-        "command": "extension.daffodil-debug.toggleFormatting",
+        "command": "extension.dfdl-debug.toggleFormatting",
         "title": "Toggle between decimal and hex formatting"
       }
     ],
@@ -135,7 +135,7 @@
           "markdown"
         ],
         "label": "Daffodil Debug",
-        "program": "./out/daffodilDebugger.js",
+        "program": "./out/extension.js",
         "runtime": "node",
         "configurationAttributes": {
           "launch": {
@@ -192,7 +192,7 @@
           }
         ],
         "variables": {
-          "AskForProgramName": "extension.daffodil-debug.getProgramName"
+          "AskForProgramName": "extension.dfdl-debug.getProgramName"
         }
       }
     ]

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -12,14 +12,14 @@ import { FileAccessor } from './daffodilRuntime';
 export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?: vscode.DebugAdapterDescriptorFactory) {
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('extension.daffodil-debug.runEditorContents', (resource: vscode.Uri) => {
+		vscode.commands.registerCommand('extension.dfdl-debug.runEditorContents', (resource: vscode.Uri) => {
 			let targetResource = resource;
 			if (!targetResource && vscode.window.activeTextEditor) {
 				targetResource = vscode.window.activeTextEditor.document.uri;
 			}
 			if (targetResource) {
 				vscode.debug.startDebugging(undefined, {
-						type: 'daffodil',
+						type: 'dfdl',
 						name: 'Run File',
 						request: 'launch',
 						program: targetResource.fsPath
@@ -28,21 +28,21 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 				);
 			}
 		}),
-		vscode.commands.registerCommand('extension.daffodil-debug.debugEditorContents', (resource: vscode.Uri) => {
+		vscode.commands.registerCommand('extension.dfdl-debug.debugEditorContents', (resource: vscode.Uri) => {
 			let targetResource = resource;
 			if (!targetResource && vscode.window.activeTextEditor) {
 				targetResource = vscode.window.activeTextEditor.document.uri;
 			}
 			if (targetResource) {
 				vscode.debug.startDebugging(undefined, {
-					type: 'daffodil',
+					type: 'dfdl',
 					name: 'Debug File',
 					request: 'launch',
 					program: targetResource.fsPath
 				});
 			}
 		}),
-		vscode.commands.registerCommand('extension.daffodil-debug.toggleFormatting', (variable) => {
+		vscode.commands.registerCommand('extension.dfdl-debug.toggleFormatting', (variable) => {
 			const ds = vscode.debug.activeDebugSession;
 			if (ds) {
 				ds.customRequest('toggleFormatting');
@@ -50,37 +50,37 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 		})
 	);
 
-	context.subscriptions.push(vscode.commands.registerCommand('extension.daffodil-debug.getProgramName', config => {
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dfdl-debug.getProgramName', config => {
 		return vscode.window.showInputBox({
 			placeHolder: "Please enter the name of a markdown file in the workspace folder",
 			value: "readme.md"
 		});
 	}));
 
-	// register a configuration provider for 'daffodil' debug type
+	// register a configuration provider for 'dfdl' debug type
 	const provider = new DaffodilConfigurationProvider();
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('daffodil', provider));
+	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('dfdl', provider));
 
-	// register a dynamic configuration provider for 'daffodil' debug type
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('daffodil', {
+	// register a dynamic configuration provider for 'dfdl' debug type
+	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('dfdl', {
 		provideDebugConfigurations(folder: WorkspaceFolder | undefined): ProviderResult<DebugConfiguration[]> {
 			return [
 				{
 					name: "Dynamic Launch",
 					request: "launch",
-					type: "daffodil",
+					type: "dfdl",
 					program: "${file}"
 				},
 				{
 					name: "Another Dynamic Launch",
 					request: "launch",
-					type: "daffodil",
+					type: "dfdl",
 					program: "${file}"
 				},
 				{
 					name: "Daffodil Launch",
 					request: "launch",
-					type: "daffodil",
+					type: "dfdl",
 					program: "${file}"
 				}
 			];
@@ -90,7 +90,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 	if (!factory) {
 		factory = new InlineDebugAdapterFactory();
 	}
-	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('daffodil', factory));
+	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('dfdl', factory));
 	if ('dispose' in factory) {
 		context.subscriptions.push(factory);
 	}
@@ -148,7 +148,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 		if (!config.type && !config.request && !config.name) {
 			const editor = vscode.window.activeTextEditor;
 			if (editor && editor.document.languageId === 'markdown') {
-				config.type = 'daffodil';
+				config.type = 'dfdl';
 				config.name = 'Launch';
 				config.request = 'launch';
 				config.program = '${file}';

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -8,7 +8,7 @@ import { HttpClient } from 'typed-rest-client/HttpClient';
 // Function for getting the da-podil debugger
 export async function getDebugger() {
     let dapodilDebuggerVersion = await vscode.window.showInputBox({'prompt': "Enter in desired dapodil debugger version:"});
-    const delay = ms => new Promise(res => setTimeout(res, ms));
+    dapodilDebuggerVersion = dapodilDebuggerVersion?.includes("v") ? dapodilDebuggerVersion : `v${dapodilDebuggerVersion}`;
 
     if(vscode.workspace.workspaceFolders !== undefined) {
         let rootPath = vscode.workspace.workspaceFolders[0].uri.path;
@@ -17,10 +17,10 @@ export async function getDebugger() {
         }
 
         // Code for downloading and setting up da-podil files
-        if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilDebuggerVersion}`)) {
+        if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}`)) {
             // Get da-podil of version entered using http client
             const client = new HttpClient("clientTest");
-            const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/v${dapodilDebuggerVersion}/daffodil-debugger-${dapodilDebuggerVersion}.zip`;
+            const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/${dapodilDebuggerVersion}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}.zip`;
             const response = await client.get(dapodilUrl);
             
             if (response.message.statusCode !== 200) {
@@ -59,10 +59,7 @@ export async function getDebugger() {
         else {
             // Linux/Mac stop debugger if already running and make sure script is executable
             child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0") // ensure debugger server not running and
-            child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebuggerVersion}/bin/da-podil`)     // make sure da-podil is executable
+            child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
         }
-
-        // Wait for 5000 ms to make sure debugger is running before the extension tries to connect to it
-        await delay(5000);
     }
 }

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -19,7 +19,7 @@ suite('Node Debug Adapter', () => {
 	let dc: DebugClient;
 
 	setup( () => {
-		dc = new DebugClient('node', DEBUG_ADAPTER, 'daffodil');
+		dc = new DebugClient('node', DEBUG_ADAPTER, 'dfdl');
 		return dc.start();
 	});
 
@@ -48,7 +48,7 @@ suite('Node Debug Adapter', () => {
 
 		test('should produce error for invalid \'pathFormat\'', done => {
 			dc.initializeRequest({
-				adapterID: 'daffodil',
+				adapterID: 'dfdl',
 				linesStartAt1: true,
 				columnsStartAt1: true,
 				pathFormat: 'url'


### PR DESCRIPTION
* Updated package.json in some places to replace daffodil to dfdl so that the download would now work properly

* Update daffodil debugger version input. it allows for the user to enter either v0.0.1 or 0.0.1 and it will work.