### PR TITLE
dapodilDebugVersion flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
               "dapodilDebugVersion": {
                 "type": "string",
                 "description": "Version of the dapoil debugger to run/use",
-                "default": "v0.0.5"
+                "default": ""
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daffodil-debug",
   "displayName": "Daffodil Debug",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "Daffodil",
   "description": "Daffodil Schema Debugger - debug Apache Daffodil schema files.",
   "author": {
@@ -168,6 +168,11 @@
                 "type": "boolean",
                 "description": "Enable connection to running DAP Server",
                 "default": false
+              },
+              "dapodilDebugVersion": {
+                "type": "string",
+                "description": "Version of the dapoil debugger to run/use",
+                "default": "v0.0.5"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
                 "description": "Enable connection to running DAP Server",
                 "default": false
               },
-              "dapodilDebugVersion": {
+              "dapodilVersion": {
                 "type": "string",
                 "description": "Version of the dapoil debugger to run/use",
                 "default": ""

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -155,7 +155,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 				config.program = '${file}';
 				config.stopOnEntry = true;
 				config.useExistingServer = false;
-				config.dapodilDebugVersion = ""
+				config.dapodilVersion = ""
 			}
 		}
 

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -155,7 +155,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 				config.program = '${file}';
 				config.stopOnEntry = true;
 				config.useExistingServer = false;
-				config.dapodilDebugVersion = "v0.0.5"
+				config.dapodilDebugVersion = ""
 			}
 		}
 

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -155,6 +155,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 				config.program = '${file}';
 				config.stopOnEntry = true;
 				config.useExistingServer = false;
+				config.dapodilDebugVersion = "v0.0.5"
 			}
 		}
 

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -25,29 +25,31 @@ export class Release {
 
 // Function for handling getting the version of the debugger
 export async function getDebugVersion(config: vscode.DebugConfiguration) {
-    const client = new RestClient("client")
-    let request = await client.get<Release[]>('https://api.github.com/repos/jw3/example-daffodil-debug/tags')
-    
-    if (request.statusCode !== 200 || !request.result) {
-        const err: Error = new Error(`Check request url, and tags of the repo. Follow this template if not already https://api.github.com/repos/{owner}/{rep_name}/tags`);
-        err["httpStatusCode"] = request.statusCode;
-        throw err;
+    if (!config.dapodilDebugVersion) {        
+        const client = new RestClient("client")
+        let request = await client.get<Release[]>('https://api.github.com/repos/jw3/example-daffodil-debug/tags')
+        
+        if (request.statusCode !== 200 || !request.result) {
+            const err: Error = new Error(`Check request url, and tags of the repo. Follow this template if not already https://api.github.com/repos/{owner}/{rep_name}/tags`);
+            err["httpStatusCode"] = request.statusCode;
+            throw err;
+        }
+
+        let releases: string[] = []
+        request.result.forEach(r => { if (r.name != "v0.0.0") releases.push(r.name); });
+
+        let dapodilDebugVersion = await vscode.window.showQuickPick(releases);
+
+        if (!dapodilDebugVersion) {
+            const err: Error = new Error(`Dapodil Debugger Version is not set or bad version entered.`);
+            throw err;
+        }
+
+        dapodilDebugVersion = dapodilDebugVersion?.includes("v") ? dapodilDebugVersion : `v${dapodilDebugVersion}`;
+        return dapodilDebugVersion
     }
 
-    let releases: string[] = []
-    request.result.forEach((release) => {
-        releases.push(release.name);
-    });
-
-    let dapodilDebuggerVersion = await vscode.window.showQuickPick(releases);
-
-    if (!dapodilDebuggerVersion || !(dapodilDebuggerVersion in releases)) {
-        const err: Error = new Error(`Dapodil Debugger Version is not set or bad version entered.`);
-        throw err;
-    }
-
-    dapodilDebuggerVersion = dapodilDebuggerVersion?.includes("v") ? dapodilDebuggerVersion : `v${dapodilDebuggerVersion}`;
-    return dapodilDebuggerVersion
+    return config.dapodilDebugVersion?.includes("v") ? config.dapodilDebugVersion : `v${config.dapodilDebugVersion}`;
 }
 
 
@@ -55,9 +57,9 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
 export async function getDebugger(config: vscode.DebugConfiguration) {
     // If useExistingServer var set to false make sure version of debugger entered is downloaded then ran
     if (!config.useExistingServer) {
-        let dapodilDebuggerVersion = await getDebugVersion(config);
+        let dapodilDebugVersion = await getDebugVersion(config);
 
-        if (!dapodilDebuggerVersion) {
+        if (!dapodilDebugVersion) {
             const err: Error = new Error(`Dapodil Debugger Version is not set or bad version entered.`);
             throw err;
         }
@@ -72,20 +74,20 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             }
 
             // Code for downloading and setting up da-podil files
-            if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}`)) {
+            if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}`)) {
                 // Get da-podil of version entered using http client
                 const client = new HttpClient("client");
-                const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/${dapodilDebuggerVersion}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}.zip`;
+                const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/${dapodilDebugVersion}/daffodil-debugger-${dapodilDebugVersion.substring(1)}.zip`;
                 const response = await client.get(dapodilUrl);
                 
                 if (response.message.statusCode !== 200) {
-                    const err: Error = new Error(`Invalid dapodil release version. Check that release for version specified exists.`);
+                    const err: Error = new Error(`Invalid dapodil release version. Check that tag specified has a release connected to it. Check that the release has zip similar to daffodil-debugger-v{tag}.zip attached to it.`);
                     err["httpStatusCode"] = response.message.statusCode;
                     throw err;
                 }
 
                 // Create zip from rest call
-                const filePath = `${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}.zip`;
+                const filePath = `${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}.zip`;
                 const file = fs.createWriteStream(filePath);
 
                 await new Promise((res, rej) => {
@@ -114,7 +116,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             else {
                 // Linux/Mac stop debugger if already running and make sure script is executable
                 child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0") // ensure debugger server not running and
-                child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
+                child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
             }
 
             // Assign script name based on os platform
@@ -123,7 +125,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             // Start debugger in terminal based on scriptName
             let terminal = vscode.window.createTerminal({
                 name: scriptName,
-                cwd: `${rootPath}/daffodil-debugger-${dapodilDebuggerVersion.substring(1)}/bin/`,
+                cwd: `${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}/bin/`,
                 hideFromUser: false,
                 shellPath: scriptName,
             });

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -25,7 +25,7 @@ export class Release {
 
 // Function for handling getting the version of the debugger
 export async function getDebugVersion(config: vscode.DebugConfiguration) {
-    if (!config.dapodilDebugVersion) {        
+    if (!config.dapodilVersion) {        
         const client = new RestClient("client")
         let request = await client.get<Release[]>('https://api.github.com/repos/jw3/example-daffodil-debug/tags')
         
@@ -38,14 +38,14 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
         let releases: string[] = []
         request.result.forEach(r => { if (r.name != "v0.0.0") releases.push(r.name); });
 
-        let dapodilDebugVersion = await vscode.window.showQuickPick(releases);
-        dapodilDebugVersion = dapodilDebugVersion ? dapodilDebugVersion : releases[0] // If dapodilDebugVersion is null use latest version
-        dapodilDebugVersion = dapodilDebugVersion?.includes("v") ? dapodilDebugVersion : `v${dapodilDebugVersion}`;
+        let dapodilVersion = await vscode.window.showQuickPick(releases);
+        dapodilVersion = dapodilVersion ? dapodilVersion : releases[0] // If dapodilVersion is null use latest version
+        dapodilVersion = dapodilVersion?.includes("v") ? dapodilVersion : `v${dapodilVersion}`;
 
-        return dapodilDebugVersion
+        return dapodilVersion
     }
 
-    return config.dapodilDebugVersion?.includes("v") ? config.dapodilDebugVersion : `v${config.dapodilDebugVersion}`;
+    return config.dapodilVersion?.includes("v") ? config.dapodilVersion : `v${config.dapodilVersion}`;
 }
 
 
@@ -53,7 +53,7 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
 export async function getDebugger(config: vscode.DebugConfiguration) {
     // If useExistingServer var set to false make sure version of debugger entered is downloaded then ran
     if (!config.useExistingServer) {
-        let dapodilDebugVersion = await getDebugVersion(config);
+        let dapodilVersion = await getDebugVersion(config);
 
         const delay = ms => new Promise(res => setTimeout(res, ms));
 
@@ -65,10 +65,10 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             }
 
             // Code for downloading and setting up da-podil files
-            if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}`)) {
+            if (!fs.existsSync(`${rootPath}/daffodil-debugger-${dapodilVersion.substring(1)}`)) {
                 // Get da-podil of version entered using http client
                 const client = new HttpClient("client");
-                const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/${dapodilDebugVersion}/daffodil-debugger-${dapodilDebugVersion.substring(1)}.zip`;
+                const dapodilUrl = `https://github.com/jw3/example-daffodil-debug/releases/download/${dapodilVersion}/daffodil-debugger-${dapodilVersion.substring(1)}.zip`;
                 const response = await client.get(dapodilUrl);
                 
                 if (response.message.statusCode !== 200) {
@@ -78,7 +78,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
                 }
 
                 // Create zip from rest call
-                const filePath = `${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}.zip`;
+                const filePath = `${rootPath}/daffodil-debugger-${dapodilVersion.substring(1)}.zip`;
                 const file = fs.createWriteStream(filePath);
 
                 await new Promise((res, rej) => {
@@ -107,7 +107,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             else {
                 // Linux/Mac stop debugger if already running and make sure script is executable
                 child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0") // ensure debugger server not running and
-                child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
+                child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
             }
 
             // Assign script name based on os platform
@@ -116,7 +116,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             // Start debugger in terminal based on scriptName
             let terminal = vscode.window.createTerminal({
                 name: scriptName,
-                cwd: `${rootPath}/daffodil-debugger-${dapodilDebugVersion.substring(1)}/bin/`,
+                cwd: `${rootPath}/daffodil-debugger-${dapodilVersion.substring(1)}/bin/`,
                 hideFromUser: false,
                 shellPath: scriptName,
             });

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -39,13 +39,9 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
         request.result.forEach(r => { if (r.name != "v0.0.0") releases.push(r.name); });
 
         let dapodilDebugVersion = await vscode.window.showQuickPick(releases);
-
-        if (!dapodilDebugVersion) {
-            const err: Error = new Error(`Dapodil Debugger Version is not set or bad version entered.`);
-            throw err;
-        }
-
+        dapodilDebugVersion = dapodilDebugVersion ? dapodilDebugVersion : releases[0] // If dapodilDebugVersion is null use latest version
         dapodilDebugVersion = dapodilDebugVersion?.includes("v") ? dapodilDebugVersion : `v${dapodilDebugVersion}`;
+
         return dapodilDebugVersion
     }
 
@@ -58,11 +54,6 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
     // If useExistingServer var set to false make sure version of debugger entered is downloaded then ran
     if (!config.useExistingServer) {
         let dapodilDebugVersion = await getDebugVersion(config);
-
-        if (!dapodilDebugVersion) {
-            const err: Error = new Error(`Dapodil Debugger Version is not set or bad version entered.`);
-            throw err;
-        }
 
         const delay = ms => new Promise(res => setTimeout(res, ms));
 


### PR DESCRIPTION
add flag "dapodilDebugVersion" to package.json so that if in the launch.json it will use that version for the debugger instead of prompting for the version.

changed variable name inside of ts from `dapodilDebuggerVersion` to `dapodilDebugVersion`.

edit `launch.json` and enter `dapodilDebugVersion` should auto pop up and the default values should be `v0.0.5`, which is the current latest version of the debugger. Then when running you should not be prompted for the version. 

closes #14 