### PR TITLE
v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daffodil-debug",
   "displayName": "Daffodil Debug",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "Daffodil",
   "description": "Daffodil Schema Debugger - debug Apache Daffodil schema files.",
   "author": {
@@ -43,7 +43,8 @@
     "await-notify": "1.0.1",
     "child_process": "^1.0.2",
     "unzip-stream": "^0.3.1",
-    "vscode-debugadapter": "^1.46.0"
+    "vscode-debugadapter": "^1.46.0",
+    "xdg-app-paths": "^7.3.0"
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -5,6 +5,9 @@ import * as os from 'os';
 import * as child_process from 'child_process';
 import { HttpClient } from 'typed-rest-client/HttpClient';
 import { RestClient } from 'typed-rest-client/RestClient';
+import XDGAppPaths from 'xdg-app-paths';
+const xdgAppPaths = XDGAppPaths({"name": "dapodil"})
+
 
 // Class for getting release data
 export class Release {
@@ -28,7 +31,7 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
     if (!config.dapodilVersion) {        
         const client = new RestClient("client")
         let request = await client.get<Release[]>('https://api.github.com/repos/jw3/example-daffodil-debug/tags')
-        
+
         if (request.statusCode !== 200 || !request.result) {
             const err: Error = new Error(`Check request url, and tags of the repo. Follow this template if not already https://api.github.com/repos/{owner}/{rep_name}/tags`);
             err["httpStatusCode"] = request.statusCode;
@@ -48,7 +51,6 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
     return config.dapodilVersion?.includes("v") ? config.dapodilVersion : `v${config.dapodilVersion}`;
 }
 
-
 // Function for getting the da-podil debugger
 export async function getDebugger(config: vscode.DebugConfiguration) {
     // If useExistingServer var set to false make sure version of debugger entered is downloaded then ran
@@ -58,10 +60,11 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
         const delay = ms => new Promise(res => setTimeout(res, ms));
 
         if(vscode.workspace.workspaceFolders !== undefined) {
-            let rootPath = vscode.workspace.workspaceFolders[0].uri.path;
+            let rootPath = xdgAppPaths.data()
 
-            if (os.platform() === 'win32') {
-                rootPath = rootPath.substring(1); // For windows the / at the start causes issues
+            // If directory for storing debugger does exist create it
+            if (!fs.existsSync(rootPath)) {
+                fs.mkdirSync(rootPath)
             }
 
             // Code for downloading and setting up da-podil files
@@ -90,7 +93,7 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
                 });
 
                 // Unzip file and remove zip file
-                await new Promise ((res, rej) => { 
+                await new Promise ((res, rej) => {
                     let stream = fs.createReadStream(filePath).pipe(unzip.Extract({ path: `${rootPath}` }));
                     stream.on("close", () => {
                         try { res(filePath); } catch (err) { rej(err); }
@@ -102,12 +105,12 @@ export async function getDebugger(config: vscode.DebugConfiguration) {
             // Stop debugger if running
             if (os.platform() === 'win32') {
                 // Windows stop debugger if already running
-                child_process.exec("tskill java");
+                child_process.execSync("tskill java");
             }
             else {
                 // Linux/Mac stop debugger if already running and make sure script is executable
-                child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0") // ensure debugger server not running and
-                child_process.exec(`chmod +x ${rootPath}/daffodil-debugger-${dapodilVersion.substring(1)}/bin/da-podil`)     // make sure da-podil is executable
+                child_process.exec("kill -9 $(ps -ef | grep 'daffodil' | grep 'jar' | awk '{ print $2 }') || return 0")     // ensure debugger server not running and
+                child_process.execSync(`chmod +x ${rootPath.replace(" ", "\\ ")}/daffodil-debugger-${dapodilVersion.substring(1)}/bin/da-podil`)    // make sure da-podil is executable
             }
 
             // Assign script name based on os platform

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,6 +2834,11 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+os-paths@^6.2.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/os-paths/-/os-paths-6.9.0.tgz#c6ab6a0a6bac700acaa415fdceb2a4c309af78fe"
+  integrity sha512-b6fbX4phQ0zydXASUr4GNAIWGtG1LzUoHdQxUpgkpYz/WszdpVGlRKkMIaLhZnRymDz4lPQfX9cx0qvDfYPmPg==
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -4128,6 +4133,20 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xdg-app-paths@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-7.3.0.tgz#8bbee36206e6be334c0331293971d30e847c29f4"
+  integrity sha512-0AIKfMMKidtt5fB9S10Hlf7qS5XTBGrzZSkSUvk7vC/4FhGFCdVn8SmigfspouEqOgLvB3Z+HmWKYu/1fXE9Dw==
+  dependencies:
+    xdg-portable "^9.0.0"
+
+xdg-portable@^9.0.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-9.4.0.tgz#cbbcffd4c9faf2f3b1c6cba04b799f885e20f31e"
+  integrity sha512-L6M5PMpxOJeT5FGnI5TjrN2jPT/rdwu+/aEjO9gbY7wLe4qq+v9oPYJpqqlaL6qNc6zE/Usmq0dvkA793nfBqw==
+  dependencies:
+    os-paths "^6.2.0"
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
* Change location of the downloaded debugger
* Location of the download version of the debugger will be inside of `$HOME/daffodil-debug`
    * If the folder `$HOME/daffodil-debug` does not exist it will be created
* This works for both Mac and Windows, should work for Linux since it does on Mac but I didn't get to test that one.

**NOTE:** If a different directory is preferred I can try to edit that for the best directory. Unless it would be preferred to create a flag that can be set for where the files will get stored, when not set if just defaults `$HOME/daffodil-debug`

closes #5 