### PR TITLE
Various updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ daffodil-debug.txt
 .DS_Store
 daffodil-debugger*
 *.debug
+*infoset*

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "activationEvents": [
     "onDebugResolve:dfdl",
     "onDebugDynamicConfigurations:dfdl",
-    "onCommand:extension.dfdl-debug.getProgramName",
+    "onCommand:extension.dfdl-debug.getDataName",
     "onCommand:extension.dfdl-debug.runEditorContents",
     "onCommand:extension.dfdl-debug.debugEditorContents"
   ],
@@ -76,21 +76,21 @@
       "editor/title/run": [
         {
           "command": "extension.dfdl-debug.runEditorContents",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == xml"
         },
         {
           "command": "extension.dfdl-debug.debugEditorContents",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == xml"
         }
       ],
       "commandPalette": [
         {
           "command": "extension.dfdl-debug.debugEditorContents",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == xml"
         },
         {
           "command": "extension.dfdl-debug.runEditorContents",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == xml"
         }
       ],
       "debug/variables/context": [
@@ -122,14 +122,14 @@
     ],
     "breakpoints": [
       {
-        "language": "markdown"
+        "language": "xml"
       }
     ],
     "debuggers": [
       {
         "type": "dfdl",
         "languages": [
-          "markdown"
+          "xml"
         ],
         "label": "Daffodil Debug",
         "program": "./out/extension.js",
@@ -152,8 +152,12 @@
                 "default": "${workspaceFolder}/${command:AskForProgramName}"
               },
               "infosetOutput": {
-                "type": "string",
-                "description": "Destination for final Infoset (file-path | 'console' | 'none')"
+                "type": "object",
+                "description": "Destination for final Infoset (file-path | 'console' | 'none')",
+                "default": {
+                  "type": "console",
+                  "path": "${workspaceFolder}/infoset.xml"
+                }
               },
               "stopOnEntry": {
                 "type": "boolean",
@@ -190,7 +194,7 @@
         "configurationSnippets": [
           {
             "label": "Daffodil Debug: Launch",
-            "description": "A new configuration for 'debugging' a user selected markdown file.",
+            "description": "A new configuration for 'debugging' a user selected xml file.",
             "body": {
               "type": "dfdl",
               "request": "launch",
@@ -201,7 +205,7 @@
           }
         ],
         "variables": {
-          "AskForProgramName": "extension.dfdl-debug.getProgramName"
+          "AskForProgramName": "extension.dfdl-debug.getDataName"
         }
       }
     ]

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,19 @@ In the Terminal you'll see log output from the debugger backend:
 
 Your schema file will also be loaded in VS Code and there should be a visible marking at the beginning where the debugger has paused upon entry to the debugging session. You can then control the debugger using the available VS Code debugger controls.
 
+### Other options for launching a debugging session
+* Option 1:
+  * Open up the schema file you wish to debug
+  * From inside the file open the Command Palette (Mac = Command+Shift+P, Windows/Linux = Ctrl+Shift+P)
+  * Once the command Palette is opened start typing `Daffodil Debug:`
+    * Option 1 = `Daffodil Debug: Debug File` - This will allow for the user to fully step through the schema (WIP), once fully completed will produce a infoset to a file named `SCHEMA-infoset.xml` which it then opened as well.
+    * Option 2 = `Daffodil Debug: Run File` - This will just run the schema through producing the infoset to a file named `SCHEMA-infoset.xml`.
+* Option 2:
+  * Open up the schema file you wish to debug
+  * Click the play button in the top right, you will get two options:
+    * Option 1 = `Debug File` - This will allow for the user to fully step through the schema (WIP), once fully completed will produce a infoset to a file named `SCHEMA-infoset.xml` which it then opened as well.
+    * Option 2 = `Run File` - This will just run the schema through producing the infoset to a file named `SCHEMA-infoset.xml` which it then opened as well.
+
 ## Build and Run as a developer 
 
 * Clone the project [https://github.com/jw3/example-daffodil-vscode.git](https://github.com/jw3/example-daffodil-vscode.git)

--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -10,10 +10,14 @@
 			"name": "Debug JPEG",
 			"program": "${workspaceFolder}/jpeg.dfdl.xsd",
 			"data": "${workspaceFolder}/works.jpg",
-			"infosetOutputPath": "${workspaceFolder}/infoset.xml",
+			"infosetOutput": {
+				"type": "file",
+				"path": "${workspaceFolder}/infoset.xml"
+			},
 			"stopOnEntry": true,
 			"trace": false,
-			"debugServer": 4711
+			"debugServer": 4711,
+			"dapodilVersion": "v0.0.7"
 		}
 	]
 }

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -70,7 +70,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 		// Open native file explorer to allow user to select data file from anywhere on their machine
 		return await vscode.window.showOpenDialog({
             canSelectMany: false, openLabel: 'Select',
-            canSelectFiles: true, canSelectFolders: true
+            canSelectFiles: true, canSelectFolders: false
         })
 		.then(fileUri => {
 			if (fileUri && fileUri[0]) {

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -9,39 +9,54 @@ import { WorkspaceFolder, DebugConfiguration, ProviderResult, CancellationToken 
 import { DaffodilDebugSession } from './daffodilDebug';
 import { getDebugger } from './daffodilDebugger';
 import { FileAccessor } from './daffodilRuntime';
+import * as path from 'path';
+
+// Function for setting up the commands for Run and Debug file
+function createDebugRunFileConfigs(resource: vscode.Uri, runOrDebug: String) {
+
+	let targetResource = resource;
+	let noDebug = runOrDebug == "run" ? true : false;
+
+	if (!targetResource && vscode.window.activeTextEditor) {
+		targetResource = vscode.window.activeTextEditor.document.uri;
+	}
+	if (targetResource) {
+		let schemaName = path.basename(targetResource.fsPath).split(".")[0]
+		let infosetFile = `${schemaName}-infoset.xml`
+
+		vscode.debug.startDebugging(undefined, {
+				type: 'dfdl',
+				name: 'Run File',
+				request: 'launch',
+				program: targetResource.fsPath,
+				data: "${command:AskForProgramName}",
+				debugServer: 4711,
+				infosetOutput: {
+					type: "file",
+					path: "${workspaceFolder}/" + infosetFile
+				}
+			},
+			{ noDebug: noDebug }
+		);
+
+		vscode.debug.onDidTerminateDebugSession(async () => {
+			if (!vscode.workspace.workspaceFolders) { return }
+			
+			vscode.workspace.openTextDocument(`${vscode.workspace.workspaceFolders[0].uri.fsPath}/${infosetFile}`).then(doc => {
+				vscode.window.showTextDocument(doc);
+			})
+		});
+	}
+}
 
 export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?: vscode.DebugAdapterDescriptorFactory) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('extension.dfdl-debug.runEditorContents', (resource: vscode.Uri) =>  {
-			let targetResource = resource;
-			if (!targetResource && vscode.window.activeTextEditor) {
-				targetResource = vscode.window.activeTextEditor.document.uri;
-			}
-			if (targetResource) {
-				vscode.debug.startDebugging(undefined, {
-						type: 'dfdl',
-						name: 'Run File',
-						request: 'launch',
-						program: targetResource.fsPath
-					},
-					{ noDebug: true }
-				);
-			}
+			createDebugRunFileConfigs(resource, "run");
 		}),
 		vscode.commands.registerCommand('extension.dfdl-debug.debugEditorContents', (resource: vscode.Uri) => {
-			let targetResource = resource;
-			if (!targetResource && vscode.window.activeTextEditor) {
-				targetResource = vscode.window.activeTextEditor.document.uri;
-			}
-			if (targetResource) {
-				vscode.debug.startDebugging(undefined, {
-					type: 'dfdl',
-					name: 'Debug File',
-					request: 'launch',
-					program: targetResource.fsPath
-				});
-			}
+			createDebugRunFileConfigs(resource, "debug");
 		}),
 		vscode.commands.registerCommand('extension.dfdl-debug.toggleFormatting', (variable) => {
 			const ds = vscode.debug.activeDebugSession;
@@ -51,10 +66,16 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 		})
 	);
 
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dfdl-debug.getProgramName', config => {
-		return vscode.window.showInputBox({
-			placeHolder: "Please enter the name of a markdown file in the workspace folder",
-			value: "readme.md"
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dfdl-debug.getDataName', async (config) => {
+		// Open native file explorer to allow user to select data file from anywhere on their machine
+		return await vscode.window.showOpenDialog({
+            canSelectMany: false, openLabel: 'Select',
+            canSelectFiles: true, canSelectFolders: true
+        })
+		.then(fileUri => {
+			if (fileUri && fileUri[0]) {
+				return fileUri[0].fsPath;
+			}
 		});
 	}));
 
@@ -97,7 +118,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 	}
 
 	// override VS Code's default implementation of the debug hover
-	context.subscriptions.push(vscode.languages.registerEvaluatableExpressionProvider('markdown', {
+	context.subscriptions.push(vscode.languages.registerEvaluatableExpressionProvider('xml', {
 		provideEvaluatableExpression(document: vscode.TextDocument, position: vscode.Position): vscode.ProviderResult<vscode.EvaluatableExpression> {
 			const wordRange = document.getWordRangeAtPosition(position);
 			return wordRange ? new vscode.EvaluatableExpression(wordRange) : undefined;
@@ -105,7 +126,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 	}));
 
 	// override VS Code's default implementation of the "inline values" feature"
-	context.subscriptions.push(vscode.languages.registerInlineValuesProvider('markdown', {
+	context.subscriptions.push(vscode.languages.registerInlineValuesProvider('xml', {
 
 		provideInlineValues(document: vscode.TextDocument, viewport: vscode.Range, context: vscode.InlineValueContext) : vscode.ProviderResult<vscode.InlineValue[]> {
 
@@ -148,14 +169,19 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 		// if launch.json is missing or empty
 		if (!config.type && !config.request && !config.name) {
 			const editor = vscode.window.activeTextEditor;
-			if (editor && editor.document.languageId === 'markdown') {
+			if (editor && editor.document.languageId === 'xml') {
 				config.type = 'dfdl';
 				config.name = 'Launch';
 				config.request = 'launch';
 				config.program = '${file}';
 				config.stopOnEntry = true;
 				config.useExistingServer = false;
-				config.dapodilVersion = ""
+				config.dapodilVersion = "";
+				config.infosetOutput = {
+					"type": "file",
+					"path": "${workspaceFolder}/${file}-infoset.xml"
+				};
+				config.debugServer = 4711;
 			}
 		}
 

--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -40,7 +40,7 @@ export async function getDebugVersion(config: vscode.DebugConfiguration) {
         let releases: string[] = []
         request.result.forEach(r => { if (r.name != "v0.0.0") releases.push(r.name); });
 
-        let dapodilVersion = await vscode.window.showQuickPick(releases);
+        let dapodilVersion = await vscode.window.showQuickPick(releases, {"ignoreFocusOut": true});
         dapodilVersion = dapodilVersion ? dapodilVersion : releases[0] // If dapodilVersion is null use latest version
         dapodilVersion = dapodilVersion?.includes("v") ? dapodilVersion : `v${dapodilVersion}`;
 


### PR DESCRIPTION
update the mapping of the infosetOutput property.

update the `Run File` and `Debug File` commands so that they will work for the dfdl xml schemas. 

updated the readme on how to utilize the `Run File` and `Debug File` commands to run a file.

updated the `Run File` and `Debug File` commands so that once they are completed they will create a file like `SCHEMA-infoset.xml` and automatically open it once debug is finished

Closes #22, closes #27 , closes #30 , closes #31  