### PR TITLE
Hex View Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ daffodil-debug.txt
 daffodil-debugger*
 *.debug
 *infoset*
+datafile-hex

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -84,7 +84,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 		});
 
 		// Create file that holds path to data file used
-		fs.writeFile(`${xdgAppPaths.data()}/.dataFile`, dataFile, function(err){
+		await fs.writeFile(`${xdgAppPaths.data()}/.dataFile`, dataFile, function(err){
 			if (err) {
 				vscode.window.showInformationMessage(`error code: ${err.code} - ${err.message}`);
 			}

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as htmlView from './hexview/htmlView';
+import * as hexView from './hexview/hexView';
 import { WorkspaceFolder, DebugConfiguration, ProviderResult, CancellationToken } from 'vscode';
 import { DaffodilDebugSession } from './daffodilDebug';
 import { getDebugger, getDataFileFromFolder } from './daffodilDebugger';
@@ -312,11 +312,11 @@ export const workspaceFileAccessor: FileAccessor = {
 
 class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
 	context: vscode.ExtensionContext;
-	htmlViewer: htmlView.DebuggerHtmlView;
+	hexViewer: hexView.DebuggerHexView;
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context;
-		this.htmlViewer = new htmlView.DebuggerHtmlView(context);
+		this.hexViewer = new hexView.DebuggerHexView(context);
 	}
 
 	createDebugAdapterDescriptor(_session: vscode.DebugSession): ProviderResult<vscode.DebugAdapterDescriptor> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 
 import * as Net from 'net';
 import * as vscode from 'vscode';
-import * as htmlView from './hexview/htmlView';
+import * as htmlView from './hexview/hexView';
 import { randomBytes } from 'crypto';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -53,11 +53,11 @@ export function deactivate() {
 
 class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
 	context: vscode.ExtensionContext;
-	htmlViewer: htmlView.DebuggerHtmlView;
+	htmlViewer: htmlView.DebuggerHexView;
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context;
-		this.htmlViewer = new htmlView.DebuggerHtmlView(context);
+		this.htmlViewer = new htmlView.DebuggerHexView(context);
 	}
 
 	// The following use of a DebugAdapter factory shows how to control what debug adapter executable is used.
@@ -89,11 +89,11 @@ class DaffodilDebugAdapterServerDescriptorFactory implements vscode.DebugAdapter
 
 	private server?: Net.Server;
 	context: vscode.ExtensionContext;
-	htmlViewer: htmlView.DebuggerHtmlView;
+	htmlViewer: htmlView.DebuggerHexView;
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context;
-		this.htmlViewer = new htmlView.DebuggerHtmlView(context);
+		this.htmlViewer = new htmlView.DebuggerHexView(context);
 	}
 
 	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
@@ -121,11 +121,11 @@ class DaffodilDebugAdapterNamedPipeServerDescriptorFactory implements vscode.Deb
 
 	private server?: Net.Server;
 	context: vscode.ExtensionContext;
-	htmlViewer: htmlView.DebuggerHtmlView;
+	htmlViewer: htmlView.DebuggerHexView;
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context;
-		this.htmlViewer = new htmlView.DebuggerHtmlView(context);
+		this.htmlViewer = new htmlView.DebuggerHexView(context);
 	}
 
 	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {

--- a/src/hexview/hexView.ts
+++ b/src/hexview/hexView.ts
@@ -112,10 +112,11 @@ export class DebuggerHexView {
     // Method for updating the line selected in the hex file using the current data position
     updateSelectedDataPosition(body: DaffodilData, hex: string) {
         let hexEditor = vscode.window.activeTextEditor;
-        let start = new vscode.Position(body.bytePos1b-1, 0);
-        let end = new vscode.Position(body.bytePos1b-1, hex.split("\n")[body.bytePos1b-1] ? hex.split("\n")[body.bytePos1b-1].length : 0);
+        let lineNum = (body.bytePos1b-1) / 16;
+        let start = new vscode.Position(lineNum, 0);
+        let end = new vscode.Position(lineNum, hex.split("\n")[lineNum] ? hex.split("\n")[lineNum].length : 0);
         let range = new vscode.Range(start, end);
-        let hexLength = hex.split("\n")[body.bytePos1b-1] ? hex.split("\n")[body.bytePos1b-1].length : body.bytePos1b;
+        let hexLength = hex.split("\n")[lineNum] ? hex.split("\n")[lineNum].length : body.bytePos1b;
 
         vscode.window.visibleTextEditors.forEach(editior => {
             if (editior.document.fileName === this.hexFile) {

--- a/src/hexview/hexView.ts
+++ b/src/hexview/hexView.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import { DisplayHtmlRequest } from "./types";
+import { DaffodilData } from "./types";
 import * as fs from "fs";
 import * as hexy from "hexy";
 import XDGAppPaths from 'xdg-app-paths';
 const xdgAppPaths = XDGAppPaths({"name": "dapodil"});
 
-export class DebuggerHtmlView {
+export class DebuggerHexView {
     context: vscode.ExtensionContext;
     dataFile: string = "";
     hexFile: string = `${xdgAppPaths.data()}/.data-hex`;
@@ -120,7 +120,7 @@ export class DebuggerHtmlView {
     }
 
     // Method to open the hex file via text editor, selecting the line at the current data position
-    openHexFile(body: DisplayHtmlRequest, hex: string) {
+    openHexFile(body: DaffodilData, hex: string) {
         let range = new vscode.Range(
             new vscode.Position(body.bytePos1b-1, 0),
             new vscode.Position(body.bytePos1b-1, hex.split("\n")[body.bytePos1b-1] ? hex.split("\n")[body.bytePos1b-1].length : 0)
@@ -144,7 +144,7 @@ export class DebuggerHtmlView {
     }
 
     // Method for updating the line selected in the hex file using the current data position
-    updateSelectedDataPosition(body: DisplayHtmlRequest, hex: string) {
+    updateSelectedDataPosition(body: DaffodilData, hex: string) {
         let hexEditor = vscode.window.activeTextEditor;
         let start = new vscode.Position(body.bytePos1b-1, 0);
         let end = new vscode.Position(body.bytePos1b-1, hex.split("\n")[body.bytePos1b-1] ? hex.split("\n")[body.bytePos1b-1].length : 0);
@@ -204,7 +204,7 @@ export class DebuggerHtmlView {
     }
 
     // Method to display the hex of the current data position sent from the debugger
-    async onDisplayHex(session: vscode.DebugSession, body: DisplayHtmlRequest) {
+    async onDisplayHex(session: vscode.DebugSession, body: DaffodilData) {
         if (!vscode.workspace.workspaceFolders) {
             return;
         }

--- a/src/hexview/types.ts
+++ b/src/hexview/types.ts
@@ -1,9 +1,3 @@
-import { ViewColumn } from "vscode";
-
-export interface DisplayHtmlRequest {
-    title: string;
-    position: ViewColumn;
-    html: string;
-    reveal: boolean;
+export interface DaffodilData {
     bytePos1b: number;
 }


### PR DESCRIPTION
- Fix issue where highlighted text and icon get stuck on a line, will now move down to the end of the file.
- Update location of data hex file so it can be reopened by the user if desired.
- Update extension to automatically close the hex file is already open in a visible editor, will also delete the data file if it exists, then opens the hex file once it is remade for the proper data file.
- Remove setting of white text color of selection

Closes #57 , Closes #58 
