### PR TITLE
Add titles to the file picker dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "activationEvents": [
     "onDebugResolve:dfdl",
     "onDebugDynamicConfigurations:dfdl",
+    "onCommand:extension.dfdl-debug.getProgramName",
     "onCommand:extension.dfdl-debug.getDataName",
     "onCommand:extension.dfdl-debug.runEditorContents",
     "onCommand:extension.dfdl-debug.debugEditorContents"
@@ -145,12 +146,12 @@
               "program": {
                 "type": "string",
                 "description": "Absolute path to the DFDL schema file.",
-                "default": "${workspaceFolder}/${command:AskForProgramName}"
+                "default": "${command:AskForProgramName}"
               },
               "data": {
                 "type": "string",
                 "description": "Absolute path to the input data file.",
-                "default": "${workspaceFolder}/${command:AskForProgramName}"
+                "default": "${command:AskForDataName}"
               },
               "infosetOutput": {
                 "type": "object",
@@ -188,9 +189,9 @@
             "type": "dfdl",
             "request": "launch",
             "name": "Ask for file name",
-            "program": "${workspaceFolder}/${command:AskForProgramName}",
+            "program": "${command:AskForProgramName}",
             "stopOnEntry": true,
-            "data": "${workspaceFolder}/${command:AskForProgramName}",
+            "data": "${command:AskForDataName}",
 				    "dapodilVersion": "v0.0.9-1",
 				    "infosetOutput": {
 					    "type": "file",
@@ -207,9 +208,9 @@
               "type": "dfdl",
               "request": "launch",
               "name": "Ask for file name",
-              "program": "^\"\\${workspaceFolder}/\\${command:AskForProgramName}\"",
+              "program": "^\"\\${command:AskForProgramName}\"",
               "stopOnEntry": true,
-              "data": "^\"\\${workspaceFolder}/\\${command:AskForProgramName}\"",
+              "data": "^\"\\${command:AskForDataName}\"",
               "dapodilVersion": "v0.0.9-1",
               "infosetOutput": {
                 "type": "file",
@@ -220,7 +221,8 @@
           }
         ],
         "variables": {
-          "AskForProgramName": "extension.dfdl-debug.getDataName"
+          "AskForProgramName": "extension.dfdl-debug.getProgramName",
+          "AskForDataName": "extension.dfdl-debug.getDataName"
         }
       }
     ]

--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -8,8 +8,8 @@
 			"type": "dfdl",
 			"request": "launch",
 			"name": "Debug JPEG",
-			"program": "${workspaceFolder}/jpeg.dfdl.xsd",
-			"data": "${workspaceFolder}/works.jpg",
+			"program": "${command:AskForProgramName}",
+			"data": "${command:AskForDataName}",
 			"infosetOutput": {
 				"type": "file",
 				"path": "${workspaceFolder}/jpeg-infoset.xml"

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -32,7 +32,7 @@ function createDebugRunFileConfigs(resource: vscode.Uri, runOrDebug: String) {
 				name: 'Run File',
 				request: 'launch',
 				program: targetResource.fsPath,
-				data: "${command:AskForProgramName}",
+				data: "${command:AskForDataName}",
 				debugServer: 4711,
 				infosetOutput: {
 					type: "file",
@@ -69,11 +69,28 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 		})
 	);
 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dfdl-debug.getProgramName', async (config) => {
+		// Open native file explorer to allow user to select data file from anywhere on their machine
+		return await vscode.window.showOpenDialog({
+            canSelectMany: false, openLabel: "Select DFDL schema to debug",
+            canSelectFiles: true, canSelectFolders: false,
+			title: "Select DFDL schema to debug"
+        })
+		.then(fileUri => {
+			if (fileUri && fileUri[0]) {
+				return fileUri[0].fsPath;
+			}
+
+			return "";
+		});
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('extension.dfdl-debug.getDataName', async (config) => {
 		// Open native file explorer to allow user to select data file from anywhere on their machine
 		let dataFile = await vscode.window.showOpenDialog({
-            canSelectMany: false, openLabel: 'Select',
-            canSelectFiles: true, canSelectFolders: false
+            canSelectMany: false, openLabel: "Select input data file to debug",
+            canSelectFiles: true, canSelectFolders: false,
+			title: "Select input data file to debug"
         })
 		.then(fileUri => {
 			if (fileUri && fileUri[0]) {
@@ -106,7 +123,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 						request: "launch",
 						type: "dfdl",
 						program: "${file}",
-						data: "${command:AskForProgramName}",
+						data: "${command:AskForDataName}",
 						debugServer: 4711,
 						infosetOutput: {
 							"type": "file",
@@ -118,7 +135,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 						request: "launch",
 						type: "dfdl",
 						program: "${file}",
-						data: "${command:AskForProgramName}",
+						data: "${command:AskForDataName}",
 						debugServer: 4711,
 						infosetOutput: {
 							"type": "file",
@@ -130,7 +147,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 						request: "launch",
 						type: "dfdl",
 						program: "${file}",
-						data: "${command:AskForProgramName}",
+						data: "${command:AskForDataName}",
 						debugServer: 4711,
 						infosetOutput: {
 							"type": "file",
@@ -149,7 +166,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 					request: "launch",
 					type: "dfdl",
 					program: "${file}",
-					data: "${command:AskForProgramName}",
+					data: "${command:AskForDataName}",
 					debugServer: 4711,
 					infosetOutput: {
 						type: "file",
@@ -161,7 +178,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 					request: "launch",
 					type: "dfdl",
 					program: "${file}",
-					data: "${command:AskForProgramName}",
+					data: "${command:AskForDataName}",
 					debugServer: 4711,
 					infosetOutput: {
 						type: "file",
@@ -173,7 +190,7 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 					request: "launch",
 					type: "dfdl",
 					program: "${file}",
-					data: "${command:AskForProgramName}",
+					data: "${command:AskForDataName}",
 					debugServer: 4711,
 					infosetOutput: {
 						type: "file",
@@ -249,7 +266,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 				config.name = 'Launch';
 				config.request = 'launch';
 				config.program = '${file}';
-				config.data = '${command:AskForProgramName}';
+				config.data = '${command:AskForDataName}';
 				config.stopOnEntry = true;
 				config.useExistingServer = false;
 				config.dapodilVersion = "v0.0.9-1";
@@ -273,7 +290,7 @@ class DaffodilConfigurationProvider implements vscode.DebugConfigurationProvider
 			dataFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
 		}
 
-		if (!dataFolder.includes("${command:AskForProgramName}") && !dataFolder.includes("${workspaceFolder}") 
+		if (!dataFolder.includes("${command:AskForProgramName}") && !dataFolder.includes("${command:AskForDataName}") && !dataFolder.includes("${workspaceFolder}") 
 			&& dataFolder.split(".").length === 1 && fs.lstatSync(dataFolder).isDirectory()) 
 		{
 			return getDataFileFromFolder(dataFolder).then(dataFile => {


### PR DESCRIPTION
* Creates another command, `AskForDataName`, so that the titles for the file pickers could be unique.
* Creates titles for the file pickers.
  * Title for `AskForProgramName` == `Select DFDL schema to debug`.
  * Title for `AskForDataName` == `Select input data file to debug`.
 * Updates the label for the open button label to be same as titles, this was added since some OS's (mac) do not show titles for the dialogs.
 * Remove `${workspaceFolder}/` from most of the defaults in the `package.json` as if you go back directories when this is set before either `${command:AskForProgramName}` or `${command:AskForDataName}` it will causes errors.

Fixes #62 
