### PR TITLE
Use config event for data file resolution

### DIFF
--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -17,7 +17,7 @@
 			"stopOnEntry": true,
 			"trace": false,
 			"debugServer": 4711,
-			"dapodilVersion": "v0.0.11"
+			"dapodilVersion": "v0.0.12"
 		}
 	]
 }

--- a/src/activateDaffodilDebug.ts
+++ b/src/activateDaffodilDebug.ts
@@ -140,13 +140,6 @@ export function activateDaffodilDebug(context: vscode.ExtensionContext, factory?
 			return "";
 		});
 
-		// Create file that holds path to data file used
-		await fs.writeFile(`${xdgAppPaths.data()}/.dataFile`, dataFile, function(err){
-			if (err) {
-				vscode.window.showInformationMessage(`error code: ${err.code} - ${err.message}`);
-			}
-		});
-
 		// If data file not selected stop launch
 		if (dataFile === "") {
 			stopDebugging();

--- a/src/daffodil.ts
+++ b/src/daffodil.ts
@@ -33,25 +33,3 @@ export interface BuildInfo {
     daffodilVersion: string,
     scalaVersion: string
 }
-
-
-
-/*
-{
-  "launchArgs": {
-    "schemaPath": "/Users/arosien/nteligen/example-daffodil-debug/src/main/resources/jpeg.dfdl.xsd",
-    "dataPath": "/Users/arosien/nteligen/example-daffodil-debug/src/main/resources/works.jpg",
-    "stopOnEntry": true,
-    "infosetOutput": {
-      "type": "console",
-      "bitmap$init$0": true
-    }
-  },
-  "buildInfo": {
-    "version": "0.0.10-SNAPSHOT",
-    "daffodilVersion": "3.1.0",
-    "scalaVersion": "2.12.13"
-  },
-  "type": "daffodil.config"
-}
-*/

--- a/src/daffodil.ts
+++ b/src/daffodil.ts
@@ -1,3 +1,8 @@
+export const dataEvent = 'daffodil.data';
+export interface DaffodilData {
+    bytePos1b: number;
+}
+
 export const infosetEvent = 'daffodil.infoset';
 export interface InfosetEvent {        
     content: string;

--- a/src/daffodil.ts
+++ b/src/daffodil.ts
@@ -10,3 +10,48 @@ export interface InfosetEvent {
     /** Default to returning the full infoset XML, but enable other encodings like diffs in the future. */
     mimeType: 'text/xml' | string;
 }
+
+export const configEvent = 'daffodil.config';
+export interface ConfigEvent {
+    launchArgs: LaunchArgs,
+    buildInfo: BuildInfo
+}
+
+export interface LaunchArgs {
+    schemaPath: string,
+    dataPath: string,
+    stopOnEntry: boolean,
+    infosetOutput: InfosetOutput
+}
+
+export interface InfosetOutput {
+    type: string
+}
+
+export interface BuildInfo {
+    version: string,
+    daffodilVersion: string,
+    scalaVersion: string
+}
+
+
+
+/*
+{
+  "launchArgs": {
+    "schemaPath": "/Users/arosien/nteligen/example-daffodil-debug/src/main/resources/jpeg.dfdl.xsd",
+    "dataPath": "/Users/arosien/nteligen/example-daffodil-debug/src/main/resources/works.jpg",
+    "stopOnEntry": true,
+    "infosetOutput": {
+      "type": "console",
+      "bitmap$init$0": true
+    }
+  },
+  "buildInfo": {
+    "version": "0.0.10-SNAPSHOT",
+    "daffodilVersion": "3.1.0",
+    "scalaVersion": "2.12.13"
+  },
+  "type": "daffodil.config"
+}
+*/

--- a/src/hexview/hexView.ts
+++ b/src/hexview/hexView.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { DaffodilData } from "./types";
 import * as fs from "fs";
 import * as hexy from "hexy";
 import XDGAppPaths from 'xdg-app-paths';
+import { DaffodilData } from "../daffodil";
 const xdgAppPaths = XDGAppPaths({"name": "dapodil"});
 
 export class DebuggerHexView {

--- a/src/hexview/hexView.ts
+++ b/src/hexview/hexView.ts
@@ -99,8 +99,8 @@ export class DebuggerHexView {
         }
     }
 
-    // Method for retrieving the data file used
-    async setDataFile(cfg: ConfigEvent) {
+    // Method for extracting the data file used
+    setDataFile(cfg: ConfigEvent) {
         this.dataFile = cfg.launchArgs.dataPath;
     }
 

--- a/src/hexview/hexView.ts
+++ b/src/hexview/hexView.ts
@@ -63,7 +63,6 @@ export class DebuggerHexView {
     // Overriden onTerminatedDebugSession method
     onTerminatedDebugSession(session: vscode.DebugSession) {
         if (session.type === 'dfdl') {
-            this.deleteFile(`${xdgAppPaths.data()}/.dataFile`);
             this.deleteFile(`${xdgAppPaths.data()}/.arrow.svg`);
             vscode.window.visibleTextEditors.forEach(editior => {
                 if (editior.document.fileName === this.hexFile) {

--- a/src/hexview/types.ts
+++ b/src/hexview/types.ts
@@ -1,3 +1,0 @@
-export interface DaffodilData {
-    bytePos1b: number;
-}


### PR DESCRIPTION
Using the `daffodil.config` event from `v0.0.12` we can take a simpler path to the data file, simplifying the resolution logic.