### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,10 +22,16 @@ jobs:
       - name: Check formatting
         run: |
           yarn run prettier src -c
+
+      - name: Get filename
+        run: |
+          GIT_ID=$(git describe)
+          VSIX_FILE="daffodil-debugger-${GIT_ID}.vsix"
+          echo "VSIX_FILE=${VSIX_FILE}" >> $GITHUB_ENV
       
       - name: Create vsix
         run: |
-          yarn run package -o extension-nightly.vsix
+          yarn run package -o ${{env.VSIX_FILE}}
       
       - name: Deploy release
         uses: WebFreak001/deploy-nightly@v1.1.0
@@ -34,7 +40,7 @@ jobs:
         with:
           upload_url: https://uploads.github.com/repos/jw3/example-daffodil-vscode/releases/45167120/assets{?name,label}
           release_id: 45167120 
-          asset_path: ${{github.workspace}}/extension-nightly.vsix
-          asset_name: daffodil-debugger-nightly.vsix
+          asset_path: ${{github.workspace}}/${{env.VSIX_FILE}}
+          asset_name: ${{env.VSIX_FILE}}
           asset_content_type: vsix
-          max_releases: 1
+          max_releases: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Check if git tag matches package version
         run: if [[ ${{env.GIT_TAG}} != ${{env.LIB_VERSION}} ]]; then exit 1; else exit 0; fi
         shell: bash
+
+      - name: Check if pre-release
+        run: |
+          if [[ ${{env.GIT_TAG}} == *"pre-"* || ${{env.GIT_TAG}} == *"-pre"* ]]; then
+            echo "PRE_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "PRE_RELEASE=false" >> $GITHUB_ENV
+          fi
+        shell: bash
       
       - name: Create backend package
         run: |
@@ -50,7 +59,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+          prerelease: "${{ env.PRE_RELEASE }}"
           files: |
             ${{github.workspace}}/daffodil-debugger-${{env.GIT_TAG}}.vsix
             ${{github.workspace}}/server/core/target/universal/daffodil-debugger-*.zip

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daffodil-debugger",
   "displayName": "Daffodil Debugger",
-  "version": "0.0.14",
+  "version": "0.0.14-pre1",
   "publisher": "jw3",
   "description": "Daffodil Schema Debugger: debug DFDL schema files using Apache Daffodil.",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Add check for both `pre-` or `-pre` on the tag sent over if the tag contains either one the release tag will be tagged as pre-release
  - https://github.com/jw3/example-daffodil-vscode/releases/tag/v0.0.14-pre1 created with check created
 - Update nightly to allow a total of 5 releases and update the name to have to be `daffodil-debbuger-${{env.GIT_ID}}` where `${{env.GIT_ID}}` is the value of `git describe`.

Closes #106 