### PR TITLE
Nightly Build Fix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,9 @@ jobs:
         run: |
           yarn run prettier src -c
 
+      - name: Yarn Compile
+        run: yarn compile
+
       - name: Get filename
         run: |
           GIT_ID=$(git describe)


### PR DESCRIPTION
- Fix issue with nightly build not being able to find `src/version.ts` as `yarn compile` needed added as a job.