### PR TITLE
Use sbt-header to add Apache 2.0 licence to Scala files.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       
       - name: Create backend package
         run: |
-          sbt universal:packageBin
+          sbt test headerCheck universal:packageBin
       
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     - run: npm install
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
-    - run: sbt compile
+    - run: sbt compile headerCheck
       if: runner.os == 'Linux'
     - run: npm test
       if: runner.os != 'Linux'

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,16 @@ lazy val daffodilVer = "3.1.0"
 
 lazy val commonSettings = {
   Seq(
-    organization := "org.apache.daffodil",
-    scalaVersion := "2.12.13",
-    scalacOptions ++= Seq("-Ypartial-unification"),
     git.useGitDescribe := true,
     libraryDependencies ++= Seq(
       "org.apache.daffodil" %% "daffodil-sapi" % daffodilVer,
       "org.apache.daffodil" %% "daffodil-runtime1" % daffodilVer,
-    )
+    ),
+    licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+    organization := "Adam Rosien, John Wass",
+    scalaVersion := "2.12.13",
+    scalacOptions ++= Seq("-Ypartial-unification"),
+    startYear := Some(2021),
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 lazy val daffodilVer = "3.1.0"
 
 lazy val commonSettings = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 sbt.version = 1.5.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")

--- a/server/core/src/main/resources/logback.xml
+++ b/server/core/src/main/resources/logback.xml
@@ -1,3 +1,19 @@
+<!--
+ Copyright 2021 Adam Rosien, John Wass
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <!-- On Windows machines setting withJansi to true enables ANSI
@@ -10,7 +26,7 @@
       <pattern>%date{ISO8601} [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Compiler.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Compiler.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.daffodil.debugger.dap
 
 import cats.effect.IO

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.daffodil.debugger.dap
 
 import cats.data._

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Next.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Next.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.daffodil.debugger.dap
 
 import cats.effect._

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.daffodil.debugger.dap
 
 import cats.Show
@@ -195,7 +211,9 @@ object Parse {
                           Either
                             .catchNonFatal(LaunchArgs.InfosetOutput.File(Paths.get(path.getAsString)))
                             .leftMap(t => s"'infosetOutput.path' field from launch request is not a valid path: $t")
-                            .ensureOr(file => s"can't write to infoset output file at ${file.path}")(_.path.toFile().canWrite())
+                            .ensureOr(file => s"can't write to infoset output file at ${file.path}")(
+                              _.path.toFile().canWrite()
+                            )
                         )
                         .toEitherNel
                     case invalidType =>

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Adam Rosien, John Wass
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.daffodil.debugger.dap
 
 import cats.Show


### PR DESCRIPTION
For completing jw3/example-daffodil-vscode#125.