### PR TITLE
Add Launch Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,21 @@
                 "type": "boolean",
                 "description": "Enable connection to running DAP Server",
                 "default": false
+              },
+              "openHexView": {
+                "type": "boolean",
+                "description": "Open hexview on debug start",
+                "default": false
+              },
+              "openInfosetView": {
+                "type": "boolean",
+                "description": "Open hexview on debug start",
+                "default": false
+              },
+              "openInfosetDiffView": {
+                "type": "boolean",
+                "description": "Open hexview on debug start",
+                "default": false
               }
             }
           }
@@ -226,7 +241,10 @@
               "type": "file",
               "path": "${workspaceFolder}/infoset.xml"
             },
-            "debugServer": 4711
+            "debugServer": 4711,
+            "openHexView": false,
+            "openInfosetView": false,
+            "openInfosetDiffView": false
           }
         ],
         "configurationSnippets": [
@@ -244,7 +262,10 @@
                 "type": "file",
                 "path": "${workspaceFolder}/infoset.xml"
               },
-              "debugServer": 4711
+              "debugServer": 4711,
+              "openHexView": false,
+              "openInfosetView": false,
+              "openInfosetDiffView": false
             }
           }
         ],

--- a/src/hexView.ts
+++ b/src/hexView.ts
@@ -21,6 +21,7 @@ import * as hexy from 'hexy'
 import XDGAppPaths from 'xdg-app-paths'
 import { ConfigEvent, DaffodilData } from './daffodil'
 const xdgAppPaths = XDGAppPaths({ name: 'dapodil' })
+import { onDebugStartDisplay } from './utils'
 
 export class DebuggerHexView {
   context: vscode.ExtensionContext
@@ -120,6 +121,19 @@ export class DebuggerHexView {
           this.onDisplayHex(e.session, e.body)
           break
       }
+
+      let hexFileOpened = false
+
+      for (var i = 0; i < vscode.window.visibleTextEditors.length; i++) {
+        let editor = vscode.window.visibleTextEditors[i]
+        if (editor.document.fileName === this.hexFile) {
+          hexFileOpened = true
+        }
+      }
+
+      if (!hexFileOpened) {
+        onDebugStartDisplay(['hex-view'])
+      }
     }
   }
 
@@ -195,7 +209,7 @@ export class DebuggerHexView {
       vscode.window
         .showTextDocument(doc, {
           selection: range,
-          viewColumn: vscode.ViewColumn.Three,
+          viewColumn: vscode.ViewColumn.Beside,
           preserveFocus: true,
           preview: false,
         })

--- a/src/infoset.ts
+++ b/src/infoset.ts
@@ -20,6 +20,7 @@ import * as daf from './daffodil'
 import * as fs from 'fs'
 import { InfosetEvent } from './daffodil'
 import { Uri } from 'vscode'
+import { onDebugStartDisplay } from './utils'
 
 export async function activate(ctx: vscode.ExtensionContext) {
   let sid: string | undefined
@@ -28,6 +29,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.debug.onDidStartDebugSession((s) => {
       sid = s.id
+      onDebugStartDisplay(['infoset-view', 'infoset-diff-view'])
     })
   )
   ctx.subscriptions.push(
@@ -53,7 +55,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
           preserveFocus: true,
-          preview: true,
+          preview: false,
         })
       }
     })
@@ -79,6 +81,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
                 case 'View':
                   let xml = await vscode.workspace.openTextDocument(uri)
                   await vscode.window.showTextDocument(xml, {
+                    preview: false,
                     viewColumn: vscode.ViewColumn.Beside,
                   })
                   break
@@ -102,7 +105,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
           'vscode.diff',
           Uri.parse(prev),
           Uri.parse(path),
-          'Previous ↔ Current'
+          'Previous ↔ Current',
+          { preview: false, viewColumn: vscode.ViewColumn.Beside }
         )
       }
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Concurrent Technologies Corporation, Nteligen LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+
+// Function to run vscode command and catch the error to not cause other issues
+export function runCommand(command: string) {
+  vscode.commands.executeCommand(command).then(undefined, (err) => {
+    vscode.window.showInformationMessage(err)
+  })
+}
+
+// Function for checking if config specifies if either the
+// infoset, infoset diff or hex view needs to be opened
+export async function onDebugStartDisplay(viewsToCheck: string[]) {
+  let config = JSON.parse(
+    JSON.stringify(
+      vscode.workspace
+        .getConfiguration(
+          'launch',
+          vscode.workspace.workspaceFolders
+            ? vscode.workspace.workspaceFolders[0].uri
+            : vscode.Uri.parse('')
+        )
+        .get('configurations')
+    )
+  )[0]
+
+  viewsToCheck.forEach(async (viewToCheck) => {
+    switch (viewToCheck) {
+      case 'hex-view':
+        if (config.openHexView) {
+          runCommand('hexview.display')
+        }
+        break
+      case 'infoset-view':
+        if (config.openInfosetView) {
+          runCommand('infoset.display')
+        }
+        break
+      case 'infoset-diff-view':
+        if (config.openInfosetDiffView) {
+          runCommand('infoset.diff')
+        }
+        break
+    }
+  })
+}


### PR DESCRIPTION
Create these additional launch options. List below shows new options:
- `openHexView` -- If set to `true` in the `launch.json` then on debug start the hexview will be opened
- `openInfosetView` -- If set to `true` in the `launch.json` then on debug start the infoset view will be opened
- `openInfosetDiffView` -- If set to `true` in the `launch.json` then on debug start the infoset diff view will be opened